### PR TITLE
feat(resize): サイドバー幅を比率からピクセルで保存する

### DIFF
--- a/src/content/core/storage.ts
+++ b/src/content/core/storage.ts
@@ -7,7 +7,7 @@ type StorageData = {
   selectedTab?: Tab;
   details?: ExtensionDetail[];
   secondaryResizeEnabled?: boolean;
-  secondaryRatio?: number | null;
+  secondaryWidth?: number | null;
 };
 
 export class StorageState {
@@ -16,14 +16,14 @@ export class StorageState {
   selectedTab: Tab | null = null;
   extensionDetails: ExtensionDetail[] | null = null;
   secondaryResizeEnabled: boolean = false;
-  secondaryRatio: number | null = null;
+  secondaryWidth: number | null = null;
   preRespWidth: ResponsiveWidth = null;
   isFirstSelected: boolean = false;
   isEventAdded: boolean = false;
   preUrl: string | null = null;
 
   async initialize(onEnableChange: (isEnabled: boolean) => void): Promise<void> {
-    const data = await chrome.storage.local.get<StorageData>(['isEnabled', 'checkedTabs', 'selectedTab', 'details', 'secondaryResizeEnabled', 'secondaryRatio']);
+    const data = await chrome.storage.local.get<StorageData>(['isEnabled', 'checkedTabs', 'selectedTab', 'details', 'secondaryResizeEnabled', 'secondaryWidth']);
 
     this.isEnabled = data.isEnabled ?? false;
     this.checkedTabs = data.checkedTabs ?? defaultCheckedTabs;
@@ -33,7 +33,7 @@ export class StorageState {
     this.selectedTab = data.selectedTab ?? defaultSelectedTab;
     this.extensionDetails = data.details ?? settingDetails;
     this.secondaryResizeEnabled = data.secondaryResizeEnabled ?? false;
-    this.secondaryRatio = data.secondaryRatio ?? null;
+    this.secondaryWidth = data.secondaryWidth ?? null;
 
     onEnableChange(this.isEnabled);
 
@@ -46,8 +46,8 @@ export class StorageState {
       if (changes.secondaryResizeEnabled) {
         this.secondaryResizeEnabled = (changes.secondaryResizeEnabled.newValue as boolean) ?? false;
       }
-      if (changes.secondaryRatio) {
-        this.secondaryRatio = (changes.secondaryRatio.newValue as number | null) ?? null;
+      if (changes.secondaryWidth) {
+        this.secondaryWidth = (changes.secondaryWidth.newValue as number | null) ?? null;
       }
     });
   }

--- a/src/content/ui/secondary-resize.ts
+++ b/src/content/ui/secondary-resize.ts
@@ -86,13 +86,17 @@ export async function setupSecondaryRatio(): Promise<void> {
     return;
   }
   try {
-    const data = await chrome.storage.local.get(['secondaryRatio']);
-    const ratio = (data.secondaryRatio ?? storageState.secondaryRatio) as number | null;
-    storageState.secondaryRatio = ratio ?? null;
+    const data = await chrome.storage.local.get(['secondaryWidth']);
+    const savedWidth = (data.secondaryWidth ?? storageState.secondaryWidth) as number | null;
+    storageState.secondaryWidth = savedWidth ?? null;
 
-    if (ratio !== null && ratio !== undefined) {
+    if (savedWidth !== null && savedWidth !== undefined) {
       const columnsWidth = columns.clientWidth;
-      const secondaryWidth = Math.floor(columnsWidth * ratio);
+      const minSecondaryWidth = 300;
+      const minPrimaryWidth = 300;
+      const maxSecondaryWidth = Math.max(columnsWidth - minPrimaryWidth, minSecondaryWidth);
+      let secondaryWidth = Math.floor(savedWidth);
+      secondaryWidth = Math.min(Math.max(secondaryWidth, minSecondaryWidth), maxSecondaryWidth);
       const primaryWidth = Math.max(columnsWidth - secondaryWidth, 0);
       applySecondaryWidths(columnsWidth, primaryWidth, { primary, secondary, ytdWatchFlexy, video });
       window.dispatchEvent(new Event('resize'));
@@ -131,9 +135,12 @@ function handleDrag(): void {
     (async () => {
       const columnsWidth = columns.clientWidth;
       const secondaryWidth = Math.round(secondary.getBoundingClientRect().width);
-      const ratio = Math.min(Math.max(secondaryWidth / columnsWidth, 0.05), 0.95);
-      await chrome.storage.local.set({ secondaryRatio: ratio });
-      storageState.secondaryRatio = ratio;
+      const minSecondaryWidth = 300;
+      const minPrimaryWidth = 300;
+      const maxSecondaryWidth = Math.max(columnsWidth - minPrimaryWidth, minSecondaryWidth);
+      const clamped = Math.min(Math.max(Math.round(secondaryWidth), minSecondaryWidth), maxSecondaryWidth);
+      await chrome.storage.local.set({ secondaryWidth: clamped });
+      storageState.secondaryWidth = clamped;
       window.dispatchEvent(new Event('resize'));
     })();
   };

--- a/src/content/ui/settings-handler.ts
+++ b/src/content/ui/settings-handler.ts
@@ -129,13 +129,13 @@ export function handleSettings(isFirstLoad: boolean): void {
       storageState.secondaryResizeEnabled = isEnabled;
 
       if (isEnabled) {
-        // 初回ON時はYouTubeデフォルト幅（secondaryRatio=null）
-        storageState.secondaryRatio = null;
-        chrome.storage.local.set({ secondaryResizeEnabled: true, secondaryRatio: null });
+        // 初回ON時はYouTubeデフォルト幅（secondaryWidth=null）
+        storageState.secondaryWidth = null;
+        chrome.storage.local.set({ secondaryResizeEnabled: true, secondaryWidth: null });
       } else {
         // OFF時は保存済み幅を無効化（デフォルト幅に戻す）
-        storageState.secondaryRatio = null;
-        chrome.storage.local.set({ secondaryResizeEnabled: false, secondaryRatio: null });
+        storageState.secondaryWidth = null;
+        chrome.storage.local.set({ secondaryResizeEnabled: false, secondaryWidth: null });
       }
 
       void applySecondaryResizeSettings();


### PR DESCRIPTION
ストレージで保持していた `secondaryRatio (0..1)` を廃止し，`secondaryWidth (px)` に置き換えた．

変更内容：

- 保存値を比率から固定幅（px）へ変更
- ユーザ操作（ドラッグ）終了時に幅を保存
- 復元時は現在のレイアウトに合わせ，min/max の範囲内でクランプして適用

BREAKING CHANGE：

- ストレージキー `secondaryRatio` を削除
- `secondaryWidth: number | null` を追加
- 既存の保存値（比率）は本変更後は読み込まれない
- 更新後，サイドバー幅は再設定が必要になる