### PR TITLE
fix: サイドバー幅調整時に動画がはみ出す問題を修正

### DIFF
--- a/src/content/style.css
+++ b/src/content/style.css
@@ -291,5 +291,4 @@ ytd-watch-flexy.yst-custom-sidebar-width {
 
 video.yst-custom-sidebar-width {
   height: auto !important;
-  width: 100% !important;
 }


### PR DESCRIPTION
https://github.com/yhotta240/youtube-comment-position-extension/pull/15 と同様の問題である．

動画要素に指定していた `width: 100% !important;` を削除することで YouTube 側のレイアウト制御を優先するように変更した．