### PR TITLE
fix: YouTube ボタン仕様変更によるレイアウト崩れを修正

### DIFF
--- a/src/content/observer.ts
+++ b/src/content/observer.ts
@@ -27,12 +27,12 @@ export function handleFirstRender(elements: YouTubeElements, checkedTabs: Tab[],
 }
 
 export function handleResize(elements: YouTubeElements, customTab: HTMLElement, isLargeScreen: boolean): void {
-  const sizeClass = 'yt-spec-button-shape-next--size-';
+  const sizeClass = 'ytSpecButtonShapeNextSize';
   if (isLargeScreen && storageState.preRespWidth === 'medium') {
     renderUI();
     Array.from(customTab.children).forEach(tab => {
-      if (tab.classList.contains(`${sizeClass}m`)) {
-        tab.classList.replace(`${sizeClass}m`, `${sizeClass}s`);
+      if (tab.classList.contains(`${sizeClass}M`)) {
+        tab.classList.replace(`${sizeClass}M`, `${sizeClass}S`);
       }
     });
     // 大画面レイアウトに合わせて要素を移動
@@ -55,8 +55,8 @@ export function handleResize(elements: YouTubeElements, customTab: HTMLElement, 
   } else if (!isLargeScreen && storageState.preRespWidth === 'large') {
     applySecondaryResizeSettings();
     Array.from(customTab.children).forEach(tab => {
-      if (tab.classList.contains(`${sizeClass}s`)) {
-        tab.classList.replace(`${sizeClass}s`, `${sizeClass}m`);
+      if (tab.classList.contains(`${sizeClass}S`)) {
+        tab.classList.replace(`${sizeClass}S`, `${sizeClass}M`);
       }
     });
     // 中画面レイアウトに合わせて要素を移動
@@ -148,11 +148,11 @@ export function handleUrlChange(): void {
       // クラスの適用
       tablist.forEach((tab, index) => {
         if (index === 0) {
-          tab.classList.remove('yt-spec-button-shape-next--segmented-interval');
-          tab.classList.add('yt-spec-button-shape-next--segmented-start');
+          tab.classList.remove('ytSpecButtonShapeNextSegmentedInterval');
+          tab.classList.add('ytSpecButtonShapeNextSegmentedStart');
         } else {
-          tab.classList.remove('yt-spec-button-shape-next--segmented-start');
-          tab.classList.add('yt-spec-button-shape-next--segmented-interval');
+          tab.classList.remove('ytSpecButtonShapeNextSegmentedStart');
+          tab.classList.add('ytSpecButtonShapeNextSegmentedInterval');
         }
       });
     }

--- a/src/content/style.css
+++ b/src/content/style.css
@@ -31,17 +31,17 @@
   padding: 0;
 }
 
-html body .yt-spec-button-shape-next--size-s.yt-spec-button-shape-next--segmented-start {
+html body .ytSpecButtonShapeNextSizeS.ytSpecButtonShapeNextSegmentedStart {
   border-radius: 10px 0 0 0;
   position: relative;
 }
 
-.yt-spec-button-shape-next--size-m.yt-spec-button-shape-next--segmented-interval {
+.ytSpecButtonShapeNextSizeM.ytSpecButtonShapeNextSegmentedInterval {
   border-radius: 0 0 0 0;
   position: relative;
 }
 
-.yt-spec-button-shape-next--size-m.yt-spec-button-shape-next--segmented-interval::after {
+.ytSpecButtonShapeNextSizeM.ytSpecButtonShapeNextSegmentedInterval::after {
   content: "";
   background: var(--segmented-bg-color, rgba(255, 255, 255, 0.2));
   position: absolute;
@@ -51,12 +51,12 @@ html body .yt-spec-button-shape-next--size-s.yt-spec-button-shape-next--segmente
   width: 1px;
 }
 
-.yt-spec-button-shape-next--size-s.yt-spec-button-shape-next--segmented-interval {
+.ytSpecButtonShapeNextSizeS.ytSpecButtonShapeNextSegmentedInterval {
   border-radius: 0 0 0 0;
   position: relative;
 }
 
-.yt-spec-button-shape-next--size-s.yt-spec-button-shape-next--segmented-interval::after {
+.ytSpecButtonShapeNextSizeS.ytSpecButtonShapeNextSegmentedInterval::after {
   content: "";
   background: var(--segmented-bg-color, rgba(255, 255, 255, 0.2));
   /* 取得できない場合のデフォルト値 */
@@ -68,7 +68,7 @@ html body .yt-spec-button-shape-next--size-s.yt-spec-button-shape-next--segmente
 }
 
 
-html body .yt-spec-button-shape-next--size-s.yt-spec-button-shape-next--segmented-end {
+html body .ytSpecButtonShapeNextSizeS.ytSpecButtonShapeNextSegmentedEnd {
   border-radius: 0 10px 0 0;
   position: relative;
 }
@@ -96,7 +96,7 @@ ytd-watch-flexy[default-layout]:not([no-top-margin]):not([reduced-top-margin]) #
   display: block;
 }
 
-html body .yt-spec-button-shape-next--mono.yt-spec-button-shape-next--tonal.custom-tab-selected {
+html body .ytSpecButtonShapeNextMono.ytSpecButtonShapeNextTonal.custom-tab-selected {
   background-color: var(--yt-spec-text-primary);
   color: var(--yt-spec-text-primary-inverse);
 }
@@ -241,7 +241,7 @@ ytd-watch-metadata #description-inner.ytd-watch-metadata #cloneCollapse.cloneBtn
   max-height: none;
 }
 
-#secondary #custom-tab button.yt-spec-button-shape-next--size-s {
+#secondary #custom-tab button.ytSpecButtonShapeNextSizeS {
   padding: 0 !important;
 }
 

--- a/src/content/ui/tab-manager.ts
+++ b/src/content/ui/tab-manager.ts
@@ -4,9 +4,9 @@ import { getElements } from '../core/elements';
 import { storageState } from '../core/storage';
 
 const SEGMENTED_CLASS = {
-  start: 'yt-spec-button-shape-next--segmented-start',
-  interval: 'yt-spec-button-shape-next--segmented-interval',
-  end: 'yt-spec-button-shape-next--segmented-end',
+  start: 'ytSpecButtonShapeNextSegmentedStart',
+  interval: 'ytSpecButtonShapeNextSegmentedInterval',
+  end: 'ytSpecButtonShapeNextSegmentedEnd',
 };
 
 export function createTab(checkedTabs: Tab[]): HTMLElement {
@@ -14,14 +14,14 @@ export function createTab(checkedTabs: Tab[]): HTMLElement {
   filteredTabs.sort((a, b) => a.num - b.num);
 
   const tab: HTMLDivElement = document.createElement('div');
-  const btnSize: string = `yt-spec-button-shape-next--size-${window.innerWidth >= 1017 ? 's' : 'm'}`;
+  const btnSize: string = `ytSpecButtonShapeNextSize${window.innerWidth >= 1017 ? 'S' : 'M'}`;
   tab.id = 'custom-tab';
   tab.classList.add('style-scope', 'yt-button-group');
   tab.style.marginBottom = `${window.innerWidth >= 1017 ? '' : '10px;'}`;
   tab.role = 'tablist';
   tab.innerHTML = /*html*/`
       <button
-        class="style-scope yt-chip-cloud-chip-renderer yt-spec-button-shape-next yt-spec-button-shape-next--tonal yt-spec-button-shape-next--mono ${btnSize} yt-spec-button-shape-next--icon-leading ${SEGMENTED_CLASS.start}"
+        class="ytSpecButtonShapeNextHost ytSpecButtonShapeNextTonal ytSpecButtonShapeNextMono ${btnSize} ytSpecButtonShapeNextIconLeading ${SEGMENTED_CLASS.start}"
         id="panels-tab"
         data-bs-toggle="pill"
         data-bs-target="#panels"
@@ -35,7 +35,7 @@ export function createTab(checkedTabs: Tab[]): HTMLElement {
       </button>
     ${filteredTabs.map((tab, index) => /*html*/`
       <button
-        class="style-scope yt-chip-cloud-chip-renderer yt-spec-button-shape-next yt-spec-button-shape-next--tonal yt-spec-button-shape-next--mono ${btnSize} yt-spec-button-shape-next--icon-leading ${index === 0 ? SEGMENTED_CLASS.start : SEGMENTED_CLASS.interval}"
+        class="ytSpecButtonShapeNextHost ytSpecButtonShapeNextTonal ytSpecButtonShapeNextMono ${btnSize} ytSpecButtonShapeNextIconLeading ${index === 0 ? SEGMENTED_CLASS.start : SEGMENTED_CLASS.interval}"
         id="${tab.id}-tab"
         data-bs-toggle="pill"
         data-bs-target="#${tab.id}"
@@ -48,7 +48,7 @@ export function createTab(checkedTabs: Tab[]): HTMLElement {
       </button>
     `).join('')}
       <button
-        class="style-scope yt-chip-cloud-chip-renderer yt-spec-button-shape-next yt-spec-button-shape-next--tonal yt-spec-button-shape-next--mono ${btnSize} yt-spec-button-shape-next--icon-leading ${SEGMENTED_CLASS.end}"
+        class="ytSpecButtonShapeNextHost ytSpecButtonShapeNextTonal ytSpecButtonShapeNextMono ${btnSize} ytSpecButtonShapeNextIconLeading ${SEGMENTED_CLASS.end}"
         id="extension-settings-tab"
         data-bs-toggle="pill"
         data-bs-target="#extension-settings"
@@ -217,7 +217,7 @@ export function addTabClickListeners(innerContent: HTMLElement): void {
   });
 }
 
-/** タブ形式の見た目にするため，yt-spec-button-shape-next--segmented クラスのスタイルを調整する */
+/** タブ形式の見た目にするため，ytSpecButtonShapeNextSegmented クラスのスタイルを調整する */
 export function updateSegmentedTabClasses(): void {
   const { customTab } = getElements();
   if (!customTab) return;


### PR DESCRIPTION
YouTube の UI 変更により，ボタン関連のクラス構造が変更され，既存の実装ではレイアウトが崩れる問題が発生していたため修正した．

変更内容：
- クラス名を従来形式から camelCase 形式へ対応
- `ytSpecButtonShapeNextHost` を追加し，YouTubeのスタイルが適用されるよう修正

補足：
`ytSpecButtonShapeNextHost` を付与しない場合，YouTube側のスタイルが適用されずレイアウトが崩れるため，本クラスは実質的に必須となっている．