### PR TITLE
fix: コメント入力欄が透過する問題を修正

### DIFF
--- a/public/comment-detail.css
+++ b/public/comment-detail.css
@@ -5,9 +5,9 @@
 }
 
 #secondary-inner #comments #header ytd-comments-header-renderer {
-  padding-bottom: var(--comments-header-renderer-margin-bottom, 12px);
-  background: var(--yt-spec-base-background);
+  padding-bottom: 12px;
+  background: var(--ytd-searchbox-background);
   border-width: 0 0 1px 0;
   border-style: solid;
-  border-color: var(--yt-spec-10-percent-layer);
+  border-color: var(--tf3fc855af2285f5f);
 }

--- a/src/content/style.css
+++ b/src/content/style.css
@@ -131,7 +131,7 @@ html body .ytSpecButtonShapeNextMono.ytSpecButtonShapeNextTonal.custom-tab-selec
   overflow-x: hidden;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--yt-spec-10-percent-layer);
+  border-color: var(--tf3fc855af2285f5f);
   border-radius: 0px 0px 12px 12px;
 }
 
@@ -141,7 +141,7 @@ html body .ytSpecButtonShapeNextMono.ytSpecButtonShapeNextTonal.custom-tab-selec
 
 #secondary-inner #comments #header ytd-comments-header-renderer {
   margin-top: 0 !important;
-  padding-top: var(--comments-header-renderer-margin-top, 12px);
+  padding-top: 12px;
   padding-inline: var(--ytd-margin-2x);
 }
 


### PR DESCRIPTION
スクロール時のコメントヘッダ（入力欄）の透過とレイアウト崩れについて対応した．
以前はダークモード対応のため YouTube の内部 CSS 変数を参照していたが，当該変数を利用できなくなったことが原因であったためである．
該当箇所を修正し、固定された状態でもコメントヘッダが常に不透明な状態で表示されるよう修正した．