### PR TITLE
fix: 概要欄をタブ化できない問題を修正

### DIFF
--- a/src/content/elements.ts
+++ b/src/content/elements.ts
@@ -1,4 +1,4 @@
-import { YouTubeElements } from "./types";
+import type { YouTubeElements } from "./types";
 
 export const getElements = (): YouTubeElements => ({
   ytdWatchFlexy: document.querySelector<HTMLElement>("ytd-watch-flexy"),
@@ -9,7 +9,7 @@ export const getElements = (): YouTubeElements => ({
   secondary: document.querySelector<HTMLElement>("#secondary.style-scope.ytd-watch-flexy"),
   secondaryInner: document.querySelector<HTMLElement>("#secondary-inner.style-scope.ytd-watch-flexy"),
   panels: document.querySelector<HTMLElement>("#panels.style-scope.ytd-watch-flexy"),
-  description: document.querySelector<HTMLElement>("#below > ytd-watch-metadata"),
+  description: document.querySelector<HTMLElement>("#columns ytd-watch-metadata")?.parentElement as HTMLElement | null,
   comments: document.querySelector<HTMLElement>("#comments.style-scope.ytd-watch-flexy"),
   related: document.querySelector<HTMLElement>("#related.style-scope.ytd-watch-flexy"),
   chatContainer: document.querySelector<HTMLElement>("#chat-container.style-scope.ytd-watch-flexy"),

--- a/src/content/ui/tab-manager.ts
+++ b/src/content/ui/tab-manager.ts
@@ -125,7 +125,8 @@ export function displayElementNone(innerContent: HTMLElement): void {
         element.setAttribute('aria-selected', 'false');
       }
       if (tab.elementName === "description") {
-        const description = document.querySelector<HTMLElement>('ytd-watch-metadata')
+        const description = elements.description;
+        console.log(description);
         if (description) description.style.display = 'none';
       }
     });
@@ -171,7 +172,7 @@ export function addTabClickListeners(innerContent: HTMLElement): void {
       if (targetContent) targetContent.style.removeProperty('display');
 
       if (targetId === '#description') {
-        const description = document.querySelector<HTMLElement>('ytd-watch-metadata')
+        const description = getElements().description;
         if (description) description.style.removeProperty('display');
       }
 


### PR DESCRIPTION
以前は，メタデータ（概要欄），コメント，関連動画などは `below` の子要素として配置されていたが，`.box` 要素でラップされる構造に変更されていた．

概要欄だけが取得できない問題が発生していたため，セレクタを見直し，その親要素全体（`.box`）を概要欄として扱うようにした．
